### PR TITLE
Fail gracefully on missing files

### DIFF
--- a/interpretEval/run_task_ner.sh
+++ b/interpretEval/run_task_ner.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -e
+
 # Task type
 task_type="ner"
 

--- a/interpretEval/tensorEvaluation-ner.py
+++ b/interpretEval/tensorEvaluation-ner.py
@@ -1926,6 +1926,8 @@ def compute_holistic_f1_re(path, delimiter = "\t"):
 
 
 def compute_holistic_f1(fn_result, delimiter = " "):
+	if not os.path.isfile(fn_result):
+		raise FileNotFoundError(f'result file not found: {fn_result}')
 	if delimiter == " ":
 		cmd = 'perl %s < %s' % (os.path.join('.', 'conlleval'), fn_result)
 

--- a/interpretEval/tensorEvaluation-ner.py
+++ b/interpretEval/tensorEvaluation-ner.py
@@ -229,9 +229,10 @@ def getAspectValue(test_word_sequences, test_trueTag_sequences, test_word_sequen
 
 			# introduce the oov density in sentence ...
 			num_oov = 0
-			for word in test_word_sequences_sent[i]:
-				if word not in dict_oov:
-					num_oov += 1
+			if dict_oov is not None:
+				for word in test_word_sequences_sent[i]:
+					if word not in dict_oov:
+						num_oov += 1
 			oDen.append(float(num_oov) / len(test_sent))
 
 			# introduce the sentence length in sentence ...
@@ -262,7 +263,7 @@ def getAspectValue(test_word_sequences, test_trueTag_sequences, test_word_sequen
 	if "oDen" in dict_aspect_func.keys():
 		eDen_list, oDen_list, sentLen_list = getSententialValue(test_trueTag_sequences_sent,
 																	 test_word_sequences_sent,
-																	 dict_preComputed_model["oDen"])
+																	 dict_preComputed_model.get("oDen", None))
 
 
 	dict_pos2sid = getPos2SentId(test_word_sequences_sent)


### PR DESCRIPTION
This PR introduces a number of robustness fixes:
* When a file is missing the current code gives a cryptic error. This adds a few small changes to make the behavior more transparent.
* The code was crashing based on a missing value for "oDen", I fixed it to check when this value was available and not use it if not.